### PR TITLE
Remove double period in icannwiki link

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -17,6 +17,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "roginfarrer",
+      "name": "Rogin Farrer",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/9063669?v=4",
+      "profile": "http://twitter.com/roginfarrer",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "contributorsPerLine": 7

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 <!-- prettier-ignore -->
-<table><tr><td align="center"><a href="https://vigneshm.com"><img src="https://avatars0.githubusercontent.com/u/14950089?v=4" width="100px;" alt="Vignesh M"/><br /><sub><b>Vignesh M</b></sub></a><br /><a href="https://github.com/SaraVieira/tld.party/commits?author=vigzmv" title="Code">💻</a></td></tr></table>
+<table><tr><td align="center"><a href="https://vigneshm.com"><img src="https://avatars0.githubusercontent.com/u/14950089?v=4" width="100px;" alt="Vignesh M"/><br /><sub><b>Vignesh M</b></sub></a><br /><a href="https://github.com/SaraVieira/tld.party/commits?author=vigzmv" title="Code">💻</a></td><td align="center"><a href="http://twitter.com/roginfarrer"><img src="https://avatars1.githubusercontent.com/u/9063669?v=4" width="100px;" alt="Rogin Farrer"/><br /><sub><b>Rogin Farrer</b></sub></a><br /><a href="https://github.com/SaraVieira/tld.party/commits?author=roginfarrer" title="Code">💻</a></td></tr></table>
 
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 

--- a/src/components/single.vue
+++ b/src/components/single.vue
@@ -2,7 +2,7 @@
   <section>
     <div class="top">
       <a
-        :href="'https://icannwiki.org/.' + tld.name.toLowerCase()"
+        :href="'https://icannwiki.org/' + tld.name.toLowerCase()"
         target="_blank"
       >
         <span>{{tld.name}}</span>


### PR DESCRIPTION
Noticed that the link had a double period that would break the link. Simply removes the period so the links resolve correctly 😄 